### PR TITLE
Move a pawn

### DIFF
--- a/cmd/chinese-checkers/cmd.go
+++ b/cmd/chinese-checkers/cmd.go
@@ -49,7 +49,7 @@ func RunCli() error {
 	chineseCheckersCommand.PersistentFlags().StringVarP(&gameStateFilePath, "state-file", "", "", "Game state file to read the board from.")
 	// Add a required move flag without shorthand.
 	chineseCheckersCommand.PersistentFlags().StringVarP(&serializedMoveList, "move", "m", "", "Move a pawn from a start position to an end position.")
-	chineseCheckersCommand.MarkFlagRequired("move")
+	chineseCheckersCommand.MarkPersistentFlagRequired("move")
 
 	// Execute the command and return the error.
 	return chineseCheckersCommand.Execute()

--- a/cmd/chinese-checkers/cmd.go
+++ b/cmd/chinese-checkers/cmd.go
@@ -9,6 +9,7 @@ import (
 )
 
 var gameStateFilePath string
+var serializedMoveList string
 
 // Initialize a game state by using the provided state file path if there is one.
 func InitGameState() (*game.BoardState, error) {
@@ -27,10 +28,18 @@ func RunCli() error {
 		Short: "Fun chinese checkers game implementation",
 		Long:  "A fun chinese checkers game implementation, to play with your sysadmin friends in a stealthy manner.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Initialize the game state, from the state file if there is one.
 			board, err := InitGameState()
 			if err != nil {
 				return err
 			}
+
+			// Move a pawn on the board.
+			if err = board.MovePawn(serializedMoveList); err != nil {
+				return err
+			}
+
+			// Print the board with the moved pawn.
 			board.Print(os.Stdout)
 			return nil
 		},
@@ -38,6 +47,9 @@ func RunCli() error {
 
 	// Add game state file flag without shorthand.
 	chineseCheckersCommand.PersistentFlags().StringVarP(&gameStateFilePath, "state-file", "", "", "Game state file to read the board from.")
+	// Add a required move flag without shorthand.
+	chineseCheckersCommand.PersistentFlags().StringVarP(&serializedMoveList, "move", "m", "", "Move a pawn from a start position to an end position.")
+	chineseCheckersCommand.MarkFlagRequired("move")
 
 	// Execute the command and return the error.
 	return chineseCheckersCommand.Execute()

--- a/internal/game/cell.go
+++ b/internal/game/cell.go
@@ -2,6 +2,7 @@ package game
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 )
 
@@ -23,7 +24,7 @@ func ParseCellIdentifier(serializedCellIdentifier string) (*CellIdentifier, erro
 		// Return the built cell identifier.
 		return &CellIdentifier{int8(row), int8(column)}, nil
 	} else {
-		return nil, errors.New("invalid cell format")
+		return nil, fmt.Errorf("invalid cell format '%s'", serializedCellIdentifier)
 	}
 }
 

--- a/internal/game/cell.go
+++ b/internal/game/cell.go
@@ -1,0 +1,28 @@
+package game
+
+import (
+	"errors"
+	"strings"
+)
+
+type Cell int8
+
+type CellIdentifier [2]int8
+
+// Parse a cell identifier from the serialized cell identifier string.
+func ParseCellIdentifier(serializedCellIdentifier string) (*CellIdentifier, error) {
+	if len(serializedCellIdentifier) == 2 {
+		// Ensure the string is lowercased.
+		serializedCellIdentifier = strings.ToLower(serializedCellIdentifier)
+
+		// Get the shift from 'a' character.
+		row := serializedCellIdentifier[0] - 'a'
+		// Get the shift from '1' character.
+		column := serializedCellIdentifier[1] - '1'
+
+		// Return the built cell identifier.
+		return &CellIdentifier{int8(row), int8(column)}, nil
+	} else {
+		return nil, errors.New("invalid cell format")
+	}
+}

--- a/internal/game/cell.go
+++ b/internal/game/cell.go
@@ -26,3 +26,25 @@ func ParseCellIdentifier(serializedCellIdentifier string) (*CellIdentifier, erro
 		return nil, errors.New("invalid cell format")
 	}
 }
+
+// Parse a move list (a list of cell identifiers) from the serialized move list string.
+func ParseMoveList(serializedMoveList string) ([]CellIdentifier, error) {
+	// Extract all the parts of the move list.
+	serializedCells := strings.Split(serializedMoveList, ",")
+	if len(serializedCells) < 2 {
+		return nil, errors.New("you must provide at least two cells in a move")
+	}
+
+	// Parse all identifiers of the list.
+	moveList := make([]CellIdentifier, len(serializedCells))
+	for moveIndex, serializedCellIdentifier := range serializedCells {
+		cellIdentifier, err := ParseCellIdentifier(serializedCellIdentifier)
+		if err != nil {
+			return nil, err
+		}
+		moveList[moveIndex] = *cellIdentifier
+	}
+
+	// Return the move list.
+	return moveList, nil
+}

--- a/internal/game/cell.go
+++ b/internal/game/cell.go
@@ -10,6 +10,11 @@ type Cell int8
 
 type CellIdentifier [2]int8
 
+// Convert a cell identifier to its string format.
+func (cellIdentifier CellIdentifier) String() string {
+	return fmt.Sprintf("%c%c", cellIdentifier[0]+'a', cellIdentifier[1]+'1')
+}
+
 // Parse a cell identifier from the serialized cell identifier string.
 func ParseCellIdentifier(serializedCellIdentifier string) (*CellIdentifier, error) {
 	// Ensure the string is lowercased and trim whitespaces.

--- a/internal/game/cell.go
+++ b/internal/game/cell.go
@@ -11,10 +11,10 @@ type CellIdentifier [2]int8
 
 // Parse a cell identifier from the serialized cell identifier string.
 func ParseCellIdentifier(serializedCellIdentifier string) (*CellIdentifier, error) {
-	if len(serializedCellIdentifier) == 2 {
-		// Ensure the string is lowercased.
-		serializedCellIdentifier = strings.ToLower(serializedCellIdentifier)
+	// Ensure the string is lowercased and trim whitespaces.
+	serializedCellIdentifier = strings.ToLower(strings.Trim(serializedCellIdentifier, " \t\n"))
 
+	if len(serializedCellIdentifier) == 2 {
 		// Get the shift from 'a' character.
 		row := serializedCellIdentifier[0] - 'a'
 		// Get the shift from '1' character.

--- a/internal/game/cell_test.go
+++ b/internal/game/cell_test.go
@@ -11,7 +11,7 @@ func TestCellIdentifierParser(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, &CellIdentifier{0, 2}, output, "should be the same identifier")
 
-	output, err = ParseCellIdentifier("h9")
+	output, err = ParseCellIdentifier(" H9")
 	assert.Nil(t, err)
 	assert.Equal(t, &CellIdentifier{7, 8}, output, "should be the same identifier")
 }

--- a/internal/game/cell_test.go
+++ b/internal/game/cell_test.go
@@ -25,6 +25,10 @@ func TestMoveListParser(t *testing.T) {
 	output, err := ParseMoveList("a1,b2,c3")
 	assert.Nil(t, err)
 	assert.Equal(t, []CellIdentifier{{0, 0}, {1, 1}, {2, 2}}, output)
+
+	output, err = ParseMoveList("b4, b3, b2, a2")
+	assert.Nil(t, err)
+	assert.Equal(t, []CellIdentifier{{1, 3}, {1, 2}, {1, 1}, {0, 1}}, output)
 }
 
 func TestMoveListSizeError(t *testing.T) {

--- a/internal/game/cell_test.go
+++ b/internal/game/cell_test.go
@@ -18,7 +18,7 @@ func TestCellIdentifierParser(t *testing.T) {
 
 func TestInvalidCellIdentifierParsing(t *testing.T) {
 	_, err := ParseCellIdentifier("a")
-	assert.Equal(t, err.Error(), "invalid cell format", "should be an invalid format error")
+	assert.Equal(t, err.Error(), "invalid cell format 'a'", "should be an invalid format error")
 }
 
 func TestMoveListParser(t *testing.T) {
@@ -38,5 +38,5 @@ func TestMoveListSizeError(t *testing.T) {
 
 func TestMoveListFormatError(t *testing.T) {
 	_, err := ParseMoveList("a1,b,c3")
-	assert.Equal(t, "invalid cell format", err.Error(), "should be an invalid format error")
+	assert.Equal(t, "invalid cell format 'b'", err.Error(), "should be an invalid format error")
 }

--- a/internal/game/cell_test.go
+++ b/internal/game/cell_test.go
@@ -17,9 +17,22 @@ func TestCellIdentifierParser(t *testing.T) {
 }
 
 func TestInvalidCellIdentifierParsing(t *testing.T) {
-	input := "a"
-
-	_, err := ParseCellIdentifier(input)
-
+	_, err := ParseCellIdentifier("a")
 	assert.Equal(t, err.Error(), "invalid cell format", "should be an invalid format error")
+}
+
+func TestMoveListParser(t *testing.T) {
+	output, err := ParseMoveList("a1,b2,c3")
+	assert.Nil(t, err)
+	assert.Equal(t, []CellIdentifier{{0, 0}, {1, 1}, {2, 2}}, output)
+}
+
+func TestMoveListSizeError(t *testing.T) {
+	_, err := ParseMoveList("a1")
+	assert.Equal(t, "you must provide at least two cells in a move", err.Error(), "should be a too small move list error")
+}
+
+func TestMoveListFormatError(t *testing.T) {
+	_, err := ParseMoveList("a1,b,c3")
+	assert.Equal(t, "invalid cell format", err.Error(), "should be an invalid format error")
 }

--- a/internal/game/cell_test.go
+++ b/internal/game/cell_test.go
@@ -1,0 +1,25 @@
+package game
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCellIdentifierParser(t *testing.T) {
+	output, err := ParseCellIdentifier("a3")
+	assert.Nil(t, err)
+	assert.Equal(t, &CellIdentifier{0, 2}, output, "should be the same identifier")
+
+	output, err = ParseCellIdentifier("h9")
+	assert.Nil(t, err)
+	assert.Equal(t, &CellIdentifier{7, 8}, output, "should be the same identifier")
+}
+
+func TestInvalidCellIdentifierParsing(t *testing.T) {
+	input := "a"
+
+	_, err := ParseCellIdentifier(input)
+
+	assert.Equal(t, err.Error(), "invalid cell format", "should be an invalid format error")
+}

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -12,7 +12,6 @@ const BoardSize = 5
 // Number of pawns of a player.
 const PlayerPawnsNumber = 6
 
-type Cell int8
 type PlayerId int8
 
 // The main board state.

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -3,6 +3,7 @@ package game
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 )
 
@@ -106,6 +107,54 @@ func (board *BoardState) Clone() *BoardState {
 	}
 
 	return clonedBoard
+}
+
+// Check that the board position is valid.
+func (board *BoardState) CheckBoardPositionValidity(position CellIdentifier) error {
+	if
+	// Check that the row index is valid.
+	(position[0] >= int8(len(board.Board)) || position[0] < 0) ||
+		// Check that the column index is valid.
+		(position[1] >= int8(len(board.Board[position[0]])) || position[1] < 0) {
+		return fmt.Errorf("%s is not a valid cell", position.String())
+	}
+	return nil
+}
+
+// Move a pawn of the board.
+func (board *BoardState) MovePawn(serializedMoveList string) error {
+	// Parse the move list.
+	moveList, err := ParseMoveList(serializedMoveList)
+	if err != nil {
+		return err
+	}
+
+	// Ensure that the position is valid for the current board.
+	if err = board.CheckBoardPositionValidity(moveList[0]); err != nil {
+		return err
+	}
+	// Ensure that there is a pawn at start position.
+	startPawn := board.Board[moveList[0][0]][moveList[0][1]]
+	if startPawn == 0 {
+		return fmt.Errorf("there is no pawn on %s", moveList[0].String())
+	}
+
+	// Ensure that the position is valid for the current board.
+	if err = board.CheckBoardPositionValidity(moveList[len(moveList)-1]); err != nil {
+		return err
+	}
+	// Ensure that there is no pawn at the end position.
+	endPawn := board.Board[moveList[len(moveList)-1][0]][moveList[len(moveList)-1][1]]
+	if endPawn != 0 {
+		return fmt.Errorf("there already is a pawn on %s", moveList[len(moveList)-1].String())
+	}
+
+	// Move the start pawn to the end position.
+	board.Board[moveList[len(moveList)-1][0]][moveList[len(moveList)-1][1]] = startPawn
+	// Remove the start pawn from its previous position.
+	board.Board[moveList[0][0]][moveList[0][1]] = 0
+
+	return nil
 }
 
 // Initialize a default board state.

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -81,3 +81,79 @@ func TestBoardCloning(t *testing.T) {
 	assert.NotSame(t, &DefaultBoard.Board, &clonedBoard.Board, "shouldn't be the same pointer")
 	assert.NotSame(t, &DefaultBoard.Board[0], &clonedBoard.Board[0], "shouldn't be the same pointer")
 }
+
+func TestMovePawnInDefaultBoard(t *testing.T) {
+	expected := &BoardState{
+		Board: [][]Cell{
+			{1, 1, 1, 0, 0},
+			{0, 1, 0, 0, 0},
+			{1, 0, 1, 0, 2},
+			{0, 0, 0, 2, 2},
+			{0, 0, 2, 2, 2},
+		},
+		CurrentPlayer: 1,
+	}
+
+	board := NewDefaultBoard()
+	err := board.MovePawn("b1,c1,c2,c3")
+	assert.Nil(t, err)
+	assert.Equal(t, expected, board)
+}
+
+func TestMovePawnInOngoingGameBoard(t *testing.T) {
+	expected := &BoardState{
+		Board: [][]Cell{
+			{0, 1, 1, 0, 0},
+			{0, 1, 0, 0, 0},
+			{1, 0, 0, 2, 0},
+			{1, 1, 2, 2, 2},
+			{0, 0, 0, 2, 2},
+		},
+		CurrentPlayer: 2,
+	}
+
+	board, err := NewBoardFromStateFile(ongoingGameStateTestPath)
+	assert.Nil(t, err)
+	err = board.MovePawn("c2,d2")
+	assert.Nil(t, err)
+	assert.Equal(t, expected, board)
+}
+
+func TestMovePawnWithNoPawnOnStartPosition(t *testing.T) {
+	board := NewDefaultBoard()
+	err := board.MovePawn("e1,c1,c2,c3")
+	assert.Equal(t, "there is no pawn on e1", err.Error(), "should return an error with no pawn on start position")
+	assert.Equal(t, &DefaultBoard, board, "should be unchanged")
+}
+
+func TestMovePawnWithAPawnOnEndPosition(t *testing.T) {
+	board := NewDefaultBoard()
+	err := board.MovePawn("a1,b1")
+	assert.Equal(t, "there already is a pawn on b1", err.Error(), "should return an error with a pawn on end position")
+	assert.Equal(t, &DefaultBoard, board, "should be unchanged")
+}
+
+func TestMovePawnErrorWithOnlyOneCell(t *testing.T) {
+	board := NewDefaultBoard()
+	err := board.MovePawn("a1")
+	assert.Equal(t, "you must provide at least two cells in a move", err.Error(), "should be a too small move list error")
+	assert.Equal(t, &DefaultBoard, board, "should be unchanged")
+}
+
+func TestMovePawnErrorWithInvalidFormat(t *testing.T) {
+	board := NewDefaultBoard()
+	err := board.MovePawn("a,b2")
+	assert.Equal(t, "invalid cell format 'a'", err.Error(), "should be an invalid format error")
+	assert.Equal(t, &DefaultBoard, board, "should be unchanged")
+}
+
+func TestMovePawnWithInvalidPosition(t *testing.T) {
+	board := NewDefaultBoard()
+	err := board.MovePawn("c1,d1,e1,f1")
+	assert.Equal(t, "f1 is not a valid cell", err.Error(), "should be an invalid cell error")
+	assert.Equal(t, &DefaultBoard, board, "should be unchanged")
+
+	err = board.MovePawn("91,d1,e1")
+	assert.Equal(t, "91 is not a valid cell", err.Error(), "should be an invalid cell error")
+	assert.Equal(t, &DefaultBoard, board, "should be unchanged")
+}


### PR DESCRIPTION
Add a way to move a pawn from a start position to an end position.

https://trello.com/c/m61zI0JJ/63-05-as-alice-i-want-to-move-a-pawn-to-a-any-free-cell

In addition to the errors described in the trello card, I added a check on the provided pawn positions to ensure that they don't go out of the board. I only check start and end positions.

## How to test

```shell
# Show that the move flag is required, with help
make build && ./bin/chinese-checkers
# Move a pawn and show the board after the move
make build && ./bin/chinese-checkers --move a1,b1,c1,d1
# Illegal move
make build && ./bin/chinese-checkers --move c1,d1,e1,f1
```