### PR TITLE
Allow simple jumps over a pawn

### DIFF
--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -138,6 +138,31 @@ func (board *BoardState) CheckMoveLegality(from CellIdentifier, to CellIdentifie
 		return nil
 	}
 
+	// Check jumps over a pawn.
+
+	if columnDiff >= 2 && rowDiff == 0 {
+		// Moving straightly in a row, check that there is ONE pawn in the middle.
+		if columnDiff > 2 {
+			return errors.New("a pawn cannot jump over more than one pawn")
+		}
+		// Check that there is a pawn in the middle of the jump.
+		middleColumn := from.Column + ((to.Column - from.Column) / 2)
+		if board.Board[middleColumn][from.Row] != EmptyCell {
+			return nil
+		}
+	}
+	if rowDiff >= 2 && columnDiff == 0 {
+		// Moving straightly in a column, check that there is ONE pawn in the middle.
+		if rowDiff > 2 {
+			return errors.New("a pawn cannot jump over more than one pawn")
+		}
+		// Check that there is a pawn in the middle of the jump.
+		middleRow := from.Row + ((to.Row - from.Row) / 2)
+		if board.Board[from.Column][middleRow] != EmptyCell {
+			return nil
+		}
+	}
+
 	// The move is illegal (more than 1 difference, or no difference).
 
 	if rowDiff == 1 && columnDiff == 1 {

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -282,10 +282,41 @@ func TestPlayersTurns(t *testing.T) {
 	board := NewDefaultBoard()
 	board.CurrentPlayer = Green // Set current player to ensure validity.
 
-	assert.Nil(t, board.MovePawn("a3,a4"), "the move is allowed")
+	assert.Nil(t, board.MovePawn("a3,a4"), "the move should be allowed")
 	assert.Equal(t, Red, board.CurrentPlayer, "red player should now be the one to play")
 	assert.Equal(t, "you cannot move a green pawn", board.MovePawn("a4,a5").Error(), "red player shouldn't be allowed to move a green pawn")
-	assert.Nil(t, board.MovePawn("e3,e2"), "the move is allowed")
+	assert.Nil(t, board.MovePawn("e3,e2"), "the move should be allowed")
 	assert.Equal(t, Green, board.CurrentPlayer, "green player should now be the one to play")
 	assert.Equal(t, "you cannot move a red pawn", board.MovePawn("e2,d2").Error(), "green player shouldn't be allowed to move a red pawn")
+}
+
+func TestJumpMoves(t *testing.T) {
+	board := NewDefaultBoard()
+	board.CurrentPlayer = Green // Set current player to ensure validity.
+
+	// Disallowed jumps of more than one pawn.
+	assert.Equal(t, "a pawn cannot jump over more than one pawn", board.MovePawn("a1,d1").Error(), "should return an illegal move error")
+	assert.Equal(t, "a pawn cannot jump over more than one pawn", board.MovePawn("a1,e1").Error(), "should return an illegal move error")
+	assert.Equal(t, "a pawn cannot jump over more than one pawn", board.MovePawn("a1,a4").Error(), "should return an illegal move error")
+	assert.Equal(t, "a pawn cannot jump over more than one pawn", board.MovePawn("a1,a5").Error(), "should return an illegal move error")
+
+	// Jump on another pawn.
+	assert.Equal(t, "there already is a pawn on a3", board.MovePawn("a1,a3").Error(), "should return that the cell is not empty")
+
+	// Valid jumps.
+	assert.Nil(t, board.MovePawn("a2,a4"), "the move should be allowed")
+	assert.Nil(t, board.MovePawn("e4,c4"), "the move should be allowed")
+
+	// Chained jumps (valid but currently disallowed).
+	assert.Equal(t, "'c2' cannot be reached from 'a4'", board.MovePawn("a4,a2,c2").Error(), "should return an illegal move error")
+
+	// Simple move.
+	assert.Nil(t, board.MovePawn("b2,b3"), "the move should be allowed")
+	board.CurrentPlayer = Green
+
+	// Error in chained jumps.
+	assert.Equal(t, "'c2' cannot be reached from 'a2'", board.MovePawn("a4,a2,c2").Error(), "should return an illegal move error")
+
+	// Diagonal jump.
+	assert.Equal(t, "'c2' cannot be reached from 'a4'", board.MovePawn("a4,c2").Error(), "should return an illegal move error")
 }


### PR DESCRIPTION
Allow to jump over a single pawn.

https://trello.com/c/28M7l35o/5-05-as-alice-i-want-to-jump-over-another-pawn

## How to test

```shell
# Test moves on default board: a2,a4 ; e4,c4 ; b1,b3 ; e5,e4 ; a4,c2 (disallowed) ; a4,a2,c2 (disallowed) ; a4,a2 ; e4,b4 (disallowed)
make run
```

## Screenshot

![show valid jumps, a2 to a4 and e4 to c4](https://github.com/user-attachments/assets/bc7ce519-3eb1-4d6c-a119-4ac197502968)
![other valid moves, b1 to b3 and e5 to e4](https://github.com/user-attachments/assets/833baf34-b7e7-46ed-a9d9-c46e3e5a85f3)
![try to jump in diagonal from a4 to c2, but it is disallowed](https://github.com/user-attachments/assets/3bb24e60-2cb9-41c1-a4ba-847a5c2ea400)
![try to jump two pawns from e4 to b4, but it is disallowed](https://github.com/user-attachments/assets/6b62ebb7-5e00-4061-8733-99e44bac9b43)
