### PR TITLE
Fix jumped pawn check: rows and columns were inverted.

### DIFF
--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -147,7 +147,7 @@ func (board *BoardState) CheckMoveLegality(from CellIdentifier, to CellIdentifie
 		}
 		// Check that there is a pawn in the middle of the jump.
 		middleColumn := from.Column + ((to.Column - from.Column) / 2)
-		if board.Board[middleColumn][from.Row] != EmptyCell {
+		if board.Board[from.Row][middleColumn] != EmptyCell {
 			return nil
 		}
 	}
@@ -158,7 +158,7 @@ func (board *BoardState) CheckMoveLegality(from CellIdentifier, to CellIdentifie
 		}
 		// Check that there is a pawn in the middle of the jump.
 		middleRow := from.Row + ((to.Row - from.Row) / 2)
-		if board.Board[from.Column][middleRow] != EmptyCell {
+		if board.Board[middleRow][from.Column] != EmptyCell {
 			return nil
 		}
 	}

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -305,7 +305,14 @@ func TestJumpMoves(t *testing.T) {
 
 	// Valid jumps.
 	assert.Nil(t, board.MovePawn("a2,a4"), "the move should be allowed")
-	assert.Nil(t, board.MovePawn("e4,c4"), "the move should be allowed")
+	assert.Nil(t, board.MovePawn("d5,d3"), "the move should be allowed")
+	board.CurrentPlayer = Red
+	assert.Nil(t, board.MovePawn("e3,c3"), "the move should be allowed")
+	board.CurrentPlayer = Red
+	assert.Nil(t, board.MovePawn("d3,e3"), "the move should be allowed")
+	board.CurrentPlayer = Red
+	assert.Equal(t, "'d2' cannot be reached from 'd4'", board.MovePawn("d4,d2").Error(), "should return an illegal move error")
+	board.CurrentPlayer = Green
 
 	// Chained jumps (valid but currently disallowed).
 	assert.Equal(t, "'c2' cannot be reached from 'a4'", board.MovePawn("a4,a2,c2").Error(), "should return an illegal move error")


### PR DESCRIPTION
As reported by Alexandra, some moves were accepted even if they were not valid. I inverted rows and columns in the middle pawn check, and didn't notice it because of the board symmetry. I've added the game situations causing the bug in the tests to ensure they won't reproduce.