### PR TITLE
Add jumps chains and disallow any adjacent move before or after a jump

### DIFF
--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -136,6 +136,11 @@ func (board *BoardState) CheckMoveLegality(from CellIdentifier, to CellIdentifie
 	// Compute the row diff of the move.
 	rowDiff := math.Abs(float64(from.Row - to.Row))
 
+	// Check that the target cell is free.
+	if board.Board[to.Row][to.Column] != EmptyCell {
+		return false, fmt.Errorf("there is already a pawn on %s", to.String())
+	}
+
 	if columnDiff+rowDiff == 1 {
 		// Only 1 difference, the move is legal.
 		return true, nil
@@ -227,12 +232,6 @@ func (board *BoardState) MovePawn(serializedMoveList string) error {
 	// Ensure that the current player can move this pawn.
 	if startPawn != Cell(board.CurrentPlayer) {
 		return fmt.Errorf("you cannot move a %s pawn", Player(startPawn).Color())
-	}
-
-	// Ensure that there is no pawn at the end position.
-	endPawn := board.Board[moveList[len(moveList)-1].Row][moveList[len(moveList)-1].Column]
-	if endPawn != EmptyCell {
-		return fmt.Errorf("there already is a pawn on %s", moveList[len(moveList)-1].String())
 	}
 
 	// Check all successive moves legality, allowing only one simple move.

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -126,8 +126,11 @@ func (board *BoardState) Clone() *BoardState {
 }
 
 // Check that the provided move is legal.
-// A move is illegal when the pawn only moves to an adjacent cell and not further.
-func (board *BoardState) CheckMoveLegality(from CellIdentifier, to CellIdentifier) error {
+// A move is legal:
+// - when the pawn moves to an adjacent cell (simple move)
+// - when the pawn jumps over another one (jump move)
+// The returned boolean indicates if the provided move is a simple move.
+func (board *BoardState) CheckMoveLegality(from CellIdentifier, to CellIdentifier) (bool, error) {
 	// Compute the column diff of the move.
 	columnDiff := math.Abs(float64(from.Column - to.Column))
 	// Compute the row diff of the move.
@@ -135,7 +138,7 @@ func (board *BoardState) CheckMoveLegality(from CellIdentifier, to CellIdentifie
 
 	if columnDiff+rowDiff == 1 {
 		// Only 1 difference, the move is legal.
-		return nil
+		return true, nil
 	}
 
 	// Check jumps over a pawn.
@@ -143,23 +146,23 @@ func (board *BoardState) CheckMoveLegality(from CellIdentifier, to CellIdentifie
 	if columnDiff >= 2 && rowDiff == 0 {
 		// Moving straightly in a row, check that there is ONE pawn in the middle.
 		if columnDiff > 2 {
-			return errors.New("a pawn cannot jump over more than one pawn")
+			return false, errors.New("a pawn cannot jump over more than one pawn")
 		}
 		// Check that there is a pawn in the middle of the jump.
 		middleColumn := from.Column + ((to.Column - from.Column) / 2)
 		if board.Board[from.Row][middleColumn] != EmptyCell {
-			return nil
+			return false, nil
 		}
 	}
 	if rowDiff >= 2 && columnDiff == 0 {
 		// Moving straightly in a column, check that there is ONE pawn in the middle.
 		if rowDiff > 2 {
-			return errors.New("a pawn cannot jump over more than one pawn")
+			return false, errors.New("a pawn cannot jump over more than one pawn")
 		}
 		// Check that there is a pawn in the middle of the jump.
 		middleRow := from.Row + ((to.Row - from.Row) / 2)
 		if board.Board[middleRow][from.Column] != EmptyCell {
-			return nil
+			return false, nil
 		}
 	}
 
@@ -167,24 +170,44 @@ func (board *BoardState) CheckMoveLegality(from CellIdentifier, to CellIdentifie
 
 	if rowDiff == 1 && columnDiff == 1 {
 		// Detected a diagonal move, return a specific error.
-		return errors.New("a pawn cannot move in diagonal")
+		return false, errors.New("a pawn cannot move in diagonal")
 	}
 
-	return fmt.Errorf("'%s' cannot be reached from '%s'", to.String(), from.String())
+	return false, fmt.Errorf("'%s' cannot be reached from '%s'", to.String(), from.String())
 }
 
 // Check legality of all successive moves.
-func (board *BoardState) CheckMovesLegality(moveList []CellIdentifier) error {
+// Simple move = move to an adjacent cell.
+func (board *BoardState) CheckMovesLegality(moveList []CellIdentifier, disallowSimpleMoves bool) error {
+	// Check move list size.
+	if len(moveList) < 2 {
+		return errors.New("you must provide at least two cells in a move")
+	}
+
+	// Check the first move of the list.
+	isSimpleMove, err := board.CheckMoveLegality(moveList[0], moveList[1])
+	if err != nil {
+		return err
+	}
+
+	// If simple moves are disallowed, check that the current move does not target an adjacent cell.
+	if disallowSimpleMoves && isSimpleMove {
+		return errors.New("cannot move to an adjacent cell after a jump")
+	}
+
 	if len(moveList) == 2 {
-		// Only 2 positions in the list = only one move, just check its legality.
-		return board.CheckMoveLegality(moveList[0], moveList[1])
+		// Only 2 positions in the list = only one move, and it's legal.
+		return nil
 	} else {
-		// More than 2 positions in the list, check the first move and the other moves recursively.
-		if err := board.CheckMoveLegality(moveList[0], moveList[1]); err != nil {
-			return err
+		// More than 2 positions in the list, check other moves recursively.
+
+		// If the current move is a simple move, no more moves are allowed, the move list should have ended.
+		if isSimpleMove {
+			return errors.New("cannot continue moving after moving to an adjacent cell")
 		}
-		// The first move is legal, check the others.
-		return board.CheckMovesLegality(moveList[1:])
+
+		// The current move is a legal jump, check the other moves with simple moves disallowed.
+		return board.CheckMovesLegality(moveList[1:], true)
 	}
 }
 
@@ -212,12 +235,8 @@ func (board *BoardState) MovePawn(serializedMoveList string) error {
 		return fmt.Errorf("there already is a pawn on %s", moveList[len(moveList)-1].String())
 	}
 
-	// Check all successive moves legality.
-	if err = board.CheckMovesLegality(moveList); err != nil {
-		return err
-	}
-	// Check entire move legality before doing it.
-	if err = board.CheckMoveLegality(moveList[0], moveList[len(moveList)-1]); err != nil {
+	// Check all successive moves legality, allowing only one simple move.
+	if err = board.CheckMovesLegality(moveList, false); err != nil {
 		return err
 	}
 

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -137,7 +137,7 @@ func TestMovePawnWithAPawnOnEndPosition(t *testing.T) {
 	board := NewDefaultBoard()
 	board.CurrentPlayer = Green // Set current player to ensure equality and validity.
 	err := board.MovePawn("a1,b1")
-	assert.Equal(t, "there already is a pawn on b1", err.Error(), "should return an error with a pawn on end position")
+	assert.Equal(t, "there is already a pawn on b1", err.Error(), "should return an error with a pawn on end position")
 	assert.Equal(t, &DefaultBoard, board, "should be unchanged")
 }
 
@@ -317,7 +317,8 @@ func TestJumpMoves(t *testing.T) {
 	assert.Equal(t, "a pawn cannot jump over more than one pawn", board.MovePawn("a1,a5").Error(), "should return an illegal move error")
 
 	// Jump on another pawn.
-	assert.Equal(t, "there already is a pawn on a3", board.MovePawn("a1,a3").Error(), "should return that the cell is not empty")
+	assert.Equal(t, "there is already a pawn on a3", board.MovePawn("a1,a3").Error(), "should return that the cell is not empty")
+	assert.Equal(t, "there is already a pawn on a3", board.MovePawn("a1,a3,a5").Error(), "should return that an intermediate cell is not empty")
 
 	// Valid simple jumps.
 	assert.Nil(t, board.MovePawn("a2,a4"), "the move should be allowed")
@@ -336,10 +337,18 @@ func TestJumpMoves(t *testing.T) {
 	assert.Nil(t, board.MovePawn("c2,a2,a4"), "the chained jumps should be allowed")
 	board.CurrentPlayer = Green
 
+	// Block a2 position with a1.
+	assert.Nil(t, board.MovePawn("a1,a2"), "the move should be allowed")
+	board.CurrentPlayer = Green
+	// Error in chained jumps, as a2 is not empty.
+	assert.Equal(t, "there is already a pawn on a2", board.MovePawn("a4,a2,c2").Error(), "should return that an intermediate cell is not empty")
+	// Free a2 position again.
+	assert.Nil(t, board.MovePawn("a2,a1"), "the move should be allowed")
+	board.CurrentPlayer = Green
+
 	// Simple move.
 	assert.Nil(t, board.MovePawn("b2,b3"), "the move should be allowed")
 	board.CurrentPlayer = Green
-
 	// Error in chained jumps, as b2 has been moved to b3.
 	assert.Equal(t, "'c2' cannot be reached from 'a2'", board.MovePawn("a4,a2,c2").Error(), "should return an illegal move error")
 


### PR DESCRIPTION
- Support jumps chains
- Disallow any adjacent move before or after a jump
- Check intermediate and final cells emptiness

https://trello.com/c/tETeowkr/6-1-as-alice-i-want-to-chain-jumps-in-a-single-turn

## How to test

```shell
# Run the game and test with the following moves: a2,a4 ; e4,e2 ; a4,a2,c2 ; c5,c4,c3 (disallowed) ; e5,e4 ; c2,a2,a4 ; e2,e4,c4 (disallowed) ; e4,c4
make run
```
## Screenshots

### Chained jumps

![jumps chain](https://github.com/user-attachments/assets/b596faf8-c3a6-4de6-8591-8b2ef22d7e8b)

### Chained jumps with a non-empty intermediate position

![there is already a pawn on e4](https://github.com/user-attachments/assets/f72d308f-7b5f-46f8-8f54-e36628dff304)

### Multiple simple moves are not allowed

![cannot continue moving after moving to an adjacent cell](https://github.com/user-attachments/assets/520b5d60-ae77-4fe8-9838-da8dccdae949)