### PR TITLE
Players target area and score

### DIFF
--- a/cmd/chinese-checkers/cmd.go
+++ b/cmd/chinese-checkers/cmd.go
@@ -43,8 +43,9 @@ func RunCli() error {
 					return err
 				}
 
-				// Print the board with the moved pawn.
+				// Print the board with the moved pawn and the current score.
 				board.Print(os.Stdout)
+				board.PrintScore(os.Stdout)
 
 				return nil
 			} else {
@@ -77,6 +78,9 @@ func runGameLoop(board *game.BoardState) {
 			println(errMsg)
 			errMsg = ""
 		}
+
+		// Show the current score.
+		board.PrintScore(os.Stdout)
 
 		// Prompt the current player for a new move list.
 		fmt.Printf("%s to play, move a pawn (e.g. a2,a4): ", cases.Title(language.English).String(board.CurrentPlayer.Color()))

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-color-term/go-color-term v0.4.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-color-term/go-color-term v0.4.0 h1:m61NaWaFyzp5iRSuYTx+rBwt/jl0sUln620asbQz4bU=
+github.com/go-color-term/go-color-term v0.4.0/go.mod h1:ctH2htEmolx6UuS7atbaz6iOfDAn95Bho223iXjC5bc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/game/cell.go
+++ b/internal/game/cell.go
@@ -71,3 +71,13 @@ func (board BoardState) ParseMoveList(serializedMoveList string) ([]CellIdentifi
 	// Return the move list.
 	return moveList, nil
 }
+
+// Determine if the cell is in the provided mask.
+func (cell CellIdentifier) InMask(cellsMask [][]Cell) bool {
+	// Detect overflows in the provided mask.
+	if cell.Row >= int8(len(cellsMask)) || cell.Column >= int8(len(cellsMask[cell.Row])) {
+		return false
+	}
+
+	return cellsMask[cell.Row][cell.Column] > 0
+}

--- a/internal/game/cell_test.go
+++ b/internal/game/cell_test.go
@@ -43,3 +43,46 @@ func TestMoveListFormatError(t *testing.T) {
 	_, err := DefaultBoard.ParseMoveList("a1,b,c3")
 	assert.Equal(t, "invalid cell format 'b'", err.Error(), "should be an invalid format error")
 }
+
+func TestCellInMask(t *testing.T) {
+	cell, err := DefaultBoard.ParseCellIdentifier("a1")
+	assert.Nil(t, err)
+	assert.True(t, cell.InMask([][]Cell{
+		{1, 0, 0, 0, 0},
+		{0, 0, 0, 0, 0},
+		{0, 0, 0, 0, 0},
+		{0, 0, 0, 0, 0},
+		{0, 0, 0, 0, 0},
+	}))
+	assert.False(t, cell.InMask([][]Cell{
+		{0, 1, 1, 1, 1},
+		{1, 1, 1, 1, 1},
+		{1, 1, 1, 1, 1},
+		{1, 1, 1, 1, 1},
+		{1, 1, 1, 1, 1},
+	}))
+	assert.False(t, cell.InMask([][]Cell{}))
+}
+
+func TestCellInTargetAreas(t *testing.T) {
+	{
+		cell, err := DefaultBoard.ParseCellIdentifier("c1")
+		assert.Nil(t, err)
+		assert.False(t, cell.InMask(GreenTargetAreaMask))
+		assert.True(t, cell.InMask(RedTargetAreaMask))
+	}
+
+	{
+		cell, err := DefaultBoard.ParseCellIdentifier("d4")
+		assert.Nil(t, err)
+		assert.True(t, cell.InMask(GreenTargetAreaMask))
+		assert.False(t, cell.InMask(RedTargetAreaMask))
+	}
+
+	{
+		cell, err := DefaultBoard.ParseCellIdentifier("e2")
+		assert.Nil(t, err)
+		assert.False(t, cell.InMask(GreenTargetAreaMask))
+		assert.False(t, cell.InMask(RedTargetAreaMask))
+	}
+}

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -294,7 +294,7 @@ func (board BoardState) CountPawnsInTargetArea(player Player, targetArea [][]Cel
 	// Evaluate all cells of the board to determine if there is a pawn in the target area.
 	for rowIndex, row := range board.Board {
 		for columnIndex, cell := range row {
-			// Initialize a cell position identifier.
+			// Initialize a cell position.
 			cellPos := CellIdentifier{int8(rowIndex), int8(columnIndex)}
 			// Check if the cell has a pawn of the player, and is in the player target area mask.
 			if cell == Cell(player) && cellPos.InMask(targetArea) {

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -34,6 +34,14 @@ var DefaultBoard = BoardState{
 	stateFile:     nil,
 }
 
+// Initialize a default board state.
+func NewDefaultBoard() *BoardState {
+	board := DefaultBoard.Clone()
+	// Chose a random player to start.
+	board.CurrentPlayer = RandomPlayer()
+	return board
+}
+
 // Initialize a board from a state file.
 func NewBoardFromStateFile(filePath string) (*BoardState, error) {
 	// Fully read the provided file.
@@ -123,6 +131,17 @@ func (board *BoardState) Clone() *BoardState {
 	}
 
 	return clonedBoard
+}
+
+// Save the board state in memory.
+func (board *BoardState) SaveState(filePath string) error {
+	// Convert the board to JSON.
+	boardJson, err := json.Marshal(board)
+	if err != nil {
+		return err
+	}
+	// Write the new state file.
+	return os.WriteFile(filePath, boardJson, 0644)
 }
 
 // Check that the provided move is legal.
@@ -267,23 +286,4 @@ func (board *BoardState) MovePawnAndSave(serializedMoveList string) error {
 		}
 	}
 	return nil
-}
-
-// Initialize a default board state.
-func NewDefaultBoard() *BoardState {
-	board := DefaultBoard.Clone()
-	// Chose a random player to start.
-	board.CurrentPlayer = RandomPlayer()
-	return board
-}
-
-// Save the board state in memory.
-func (board *BoardState) SaveState(filePath string) error {
-	// Convert the board to JSON.
-	boardJson, err := json.Marshal(board)
-	if err != nil {
-		return err
-	}
-	// Write the new state file.
-	return os.WriteFile(filePath, boardJson, 0644)
 }

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -288,29 +288,23 @@ func (board *BoardState) MovePawnAndSave(serializedMoveList string) error {
 	return nil
 }
 
-// Count pawns of the provided player that are in the provided target area.
-func (board BoardState) CountPawnsInTargetArea(player Player, targetArea [][]Cell) int8 {
-	pawns := int8(0)
+// Count pawns of each player that are in the player target area.
+func (board BoardState) CountPawnsInTargetAreas() (int8, int8) {
+	greenPawns := int8(0)
+	redPawns := int8(0)
 	// Evaluate all cells of the board to determine if there is a pawn in the target area.
 	for rowIndex, row := range board.Board {
 		for columnIndex, cell := range row {
 			// Initialize a cell position.
 			cellPos := CellIdentifier{int8(rowIndex), int8(columnIndex)}
-			// Check if the cell has a pawn of the player, and is in the player target area mask.
-			if cell == Cell(player) && cellPos.InMask(targetArea) {
-				pawns++
+
+			// Increment the pawns counter of the player if it is in the target area mask.
+			if cell == GreenCell && cellPos.InMask(GreenTargetAreaMask) {
+				greenPawns++
+			} else if cell == RedCell && cellPos.InMask(RedTargetAreaMask) {
+				redPawns++
 			}
 		}
 	}
-	return pawns
-}
-
-// Count green pawns in the green target area.
-func (board BoardState) CountGreenPawnsInTargetArea() int8 {
-	return board.CountPawnsInTargetArea(Green, GreenTargetAreaMask)
-}
-
-// Count red pawns in the red target area.
-func (board BoardState) CountRedPawnsInTargetArea() int8 {
-	return board.CountPawnsInTargetArea(Red, RedTargetAreaMask)
+	return greenPawns, redPawns
 }

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -289,9 +289,7 @@ func (board *BoardState) MovePawnAndSave(serializedMoveList string) error {
 }
 
 // Count pawns of each player that are in the player target area.
-func (board BoardState) CountPawnsInTargetAreas() (int8, int8) {
-	greenPawns := int8(0)
-	redPawns := int8(0)
+func (board BoardState) CountPawnsInTargetAreas() (greenPawns int8, redPawns int8) {
 	// Evaluate all cells of the board to determine if there is a pawn in the target area.
 	for rowIndex, row := range board.Board {
 		for columnIndex, cell := range row {

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -287,3 +287,30 @@ func (board *BoardState) MovePawnAndSave(serializedMoveList string) error {
 	}
 	return nil
 }
+
+// Count pawns of the provided player that are in the provided target area.
+func (board BoardState) CountPawnsInTargetArea(player Player, targetArea [][]Cell) int8 {
+	pawns := int8(0)
+	// Evaluate all cells of the board to determine if there is a pawn in the target area.
+	for rowIndex, row := range board.Board {
+		for columnIndex, cell := range row {
+			// Initialize a cell position identifier.
+			cellPos := CellIdentifier{int8(rowIndex), int8(columnIndex)}
+			// Check if the cell has a pawn of the player, and is in the player target area mask.
+			if cell == Cell(player) && cellPos.InMask(targetArea) {
+				pawns++
+			}
+		}
+	}
+	return pawns
+}
+
+// Count green pawns in the green target area.
+func (board BoardState) CountGreenPawnsInTargetArea() int8 {
+	return board.CountPawnsInTargetArea(Green, GreenTargetAreaMask)
+}
+
+// Count red pawns in the red target area.
+func (board BoardState) CountRedPawnsInTargetArea() int8 {
+	return board.CountPawnsInTargetArea(Red, RedTargetAreaMask)
+}

--- a/internal/game/game_cli.go
+++ b/internal/game/game_cli.go
@@ -44,9 +44,10 @@ func (board *BoardState) Print(writer io.Writer) {
 
 // Print the current game score.
 func (board *BoardState) PrintScore(writer io.Writer) {
+	greenPawns, redPawns := board.CountPawnsInTargetAreas()
 	fmt.Fprintf(writer,
 		coloring.For("Green").Bold().Green().String()+": %d/%d, "+coloring.For("Red").Bold().Red().String()+": %d/%d\n",
-		board.CountGreenPawnsInTargetArea(), PlayerPawnsNumber,
-		board.CountRedPawnsInTargetArea(), PlayerPawnsNumber,
+		greenPawns, PlayerPawnsNumber,
+		redPawns, PlayerPawnsNumber,
 	)
 }

--- a/internal/game/game_cli.go
+++ b/internal/game/game_cli.go
@@ -41,3 +41,12 @@ func (board *BoardState) Print(writer io.Writer) {
 		fmt.Fprintln(writer, " . +----+----+----+----+----+")
 	}
 }
+
+// Print the current game score.
+func (board *BoardState) PrintScore(writer io.Writer) {
+	fmt.Fprintf(writer,
+		coloring.For("Green").Bold().Green().String()+": %d/%d, "+coloring.For("Red").Bold().Red().String()+": %d/%d\n",
+		board.CountGreenPawnsInTargetArea(), PlayerPawnsNumber,
+		board.CountRedPawnsInTargetArea(), PlayerPawnsNumber,
+	)
+}

--- a/internal/game/game_cli.go
+++ b/internal/game/game_cli.go
@@ -3,6 +3,8 @@ package game
 import (
 	"fmt"
 	"io"
+
+	"github.com/go-color-term/go-color-term/coloring"
 )
 
 // Print the game board to the console.
@@ -12,11 +14,24 @@ func (board *BoardState) Print(writer io.Writer) {
 	for rowIndex, row := range board.Board {
 		fmt.Fprintf(writer, " %c ", rune(int('a')+rowIndex))
 		fmt.Fprint(writer, "|")
-		for _, cell := range row {
-			if cell == 1 {
-				fmt.Fprint(writer, " 🟢 ")
-			} else if cell == 2 {
-				fmt.Fprint(writer, " 🔴 ")
+		for columnIndex, cell := range row {
+			// Initialize a cell position.
+			cellPos := CellIdentifier{int8(rowIndex), int8(columnIndex)}
+
+			if cell == GreenCell {
+				pawnCellStr := " 🟢 "
+				if cellPos.InMask(GreenTargetAreaMask) {
+					// The cell is in the target area, add a background color.
+					pawnCellStr = coloring.For(pawnCellStr).Background().Rgb(0, 70, 0).String()
+				}
+				fmt.Fprint(writer, pawnCellStr)
+			} else if cell == RedCell {
+				pawnCellStr := " 🔴 "
+				if cellPos.InMask(RedTargetAreaMask) {
+					// The cell is in the target area, add a background color.
+					pawnCellStr = coloring.For(pawnCellStr).Background().Rgb(84, 0, 0).String()
+				}
+				fmt.Fprint(writer, pawnCellStr)
 			} else {
 				fmt.Fprint(writer, "    ")
 			}

--- a/internal/game/game_cli_test.go
+++ b/internal/game/game_cli_test.go
@@ -82,3 +82,34 @@ func TestBoardPrintingWithPawnsInTargetArea(t *testing.T) {
 
 	assert.Equal(t, expected, output.String(), "should have printed a default board")
 }
+
+func TestBoardScorePrinting(t *testing.T) {
+	{
+		expected := coloring.For("Green").Bold().Green().String() + ": 0/6, " + coloring.For("Red").Bold().Red().String() + ": 0/6\n"
+
+		board := NewDefaultBoard()
+
+		var output bytes.Buffer
+		board.PrintScore(&output)
+
+		assert.Equal(t, expected, output.String(), "should have printed an accurate scoreboard")
+	}
+
+	{
+		expected := coloring.For("Green").Bold().Green().String() + ": 3/6, " + coloring.For("Red").Bold().Red().String() + ": 3/6\n"
+
+		board := NewDefaultBoard()
+		board.Board = [][]Cell{
+			{1, 1, 2, 0, 0},
+			{1, 2, 0, 0, 0},
+			{2, 0, 0, 0, 1},
+			{0, 0, 0, 1, 2},
+			{0, 0, 1, 2, 2},
+		}
+
+		var output bytes.Buffer
+		board.PrintScore(&output)
+
+		assert.Equal(t, expected, output.String(), "should have printed an accurate scoreboard")
+	}
+}

--- a/internal/game/game_cli_test.go
+++ b/internal/game/game_cli_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/go-color-term/go-color-term/coloring"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -50,4 +51,34 @@ func TestOngoingGameBoardPrinting(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, expected, output.String(), "should have printed an ongoing game board")
+}
+
+func TestBoardPrintingWithPawnsInTargetArea(t *testing.T) {
+	expected := `     1    2    3    4    5  
+ . +----+----+----+----+----+
+ a | 🟢 | 🟢 |` + coloring.For(" 🔴 ").Background().Rgb(84, 0, 0).String() + `|    |    |
+ . +----+----+----+----+----+
+ b | 🟢 |` + coloring.For(" 🔴 ").Background().Rgb(84, 0, 0).String() + `|    |    |    |
+ . +----+----+----+----+----+
+ c |` + coloring.For(" 🔴 ").Background().Rgb(84, 0, 0).String() + `|    |    |    |` + coloring.For(" 🟢 ").Background().Rgb(0, 70, 0).String() + `|
+ . +----+----+----+----+----+
+ d |    |    |    |` + coloring.For(" 🟢 ").Background().Rgb(0, 70, 0).String() + `| 🔴 |
+ . +----+----+----+----+----+
+ e |    |    |` + coloring.For(" 🟢 ").Background().Rgb(0, 70, 0).String() + `| 🔴 | 🔴 |
+ . +----+----+----+----+----+
+`
+
+	board := NewDefaultBoard()
+	board.Board = [][]Cell{
+		{1, 1, 2, 0, 0},
+		{1, 2, 0, 0, 0},
+		{2, 0, 0, 0, 1},
+		{0, 0, 0, 1, 2},
+		{0, 0, 1, 2, 2},
+	}
+
+	var output bytes.Buffer
+	board.Print(&output)
+
+	assert.Equal(t, expected, output.String(), "should have printed a default board")
 }

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -359,8 +359,9 @@ func TestJumpMoves(t *testing.T) {
 func TestPawnsInTargetArea(t *testing.T) {
 	{
 		board := NewDefaultBoard()
-		assert.Equal(t, int8(0), board.CountGreenPawnsInTargetArea(), "should have no green pawn in target area")
-		assert.Equal(t, int8(0), board.CountRedPawnsInTargetArea(), "should have no red pawn in target area")
+		greenPawns, redPawns := board.CountPawnsInTargetAreas()
+		assert.Equal(t, int8(0), greenPawns, "should have no green pawn in target area")
+		assert.Equal(t, int8(0), redPawns, "should have no red pawn in target area")
 	}
 
 	{
@@ -372,8 +373,9 @@ func TestPawnsInTargetArea(t *testing.T) {
 			{0, 0, 0, 1, 1},
 			{0, 0, 1, 1, 1},
 		}
-		assert.Equal(t, int8(6), board.CountGreenPawnsInTargetArea(), "should have 6 green pawns in target area")
-		assert.Equal(t, int8(6), board.CountRedPawnsInTargetArea(), "should have 6 red pawns in target area")
+		greenPawns, redPawns := board.CountPawnsInTargetAreas()
+		assert.Equal(t, int8(6), greenPawns, "should have 6 green pawns in target area")
+		assert.Equal(t, int8(6), redPawns, "should have 6 red pawns in target area")
 	}
 
 	{
@@ -385,7 +387,8 @@ func TestPawnsInTargetArea(t *testing.T) {
 			{0, 2, 1, 0, 1},
 			{2, 0, 1, 0, 1},
 		}
-		assert.Equal(t, int8(4), board.CountGreenPawnsInTargetArea(), "should have 4 green pawns in target area")
-		assert.Equal(t, int8(1), board.CountRedPawnsInTargetArea(), "should have 1 red pawn in target area")
+		greenPawns, redPawns := board.CountPawnsInTargetAreas()
+		assert.Equal(t, int8(4), greenPawns, "should have 4 green pawns in target area")
+		assert.Equal(t, int8(1), redPawns, "should have 1 red pawn in target area")
 	}
 }

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -355,3 +355,37 @@ func TestJumpMoves(t *testing.T) {
 	// Diagonal jump is disallowed.
 	assert.Equal(t, "'c2' cannot be reached from 'a4'", board.MovePawn("a4,c2").Error(), "should return an illegal move error")
 }
+
+func TestPawnsInTargetArea(t *testing.T) {
+	{
+		board := NewDefaultBoard()
+		assert.Equal(t, int8(0), board.CountGreenPawnsInTargetArea(), "should have no green pawn in target area")
+		assert.Equal(t, int8(0), board.CountRedPawnsInTargetArea(), "should have no red pawn in target area")
+	}
+
+	{
+		board := NewDefaultBoard()
+		board.Board = [][]Cell{
+			{2, 2, 2, 0, 0},
+			{2, 2, 0, 0, 0},
+			{2, 0, 0, 0, 1},
+			{0, 0, 0, 1, 1},
+			{0, 0, 1, 1, 1},
+		}
+		assert.Equal(t, int8(6), board.CountGreenPawnsInTargetArea(), "should have 6 green pawns in target area")
+		assert.Equal(t, int8(6), board.CountRedPawnsInTargetArea(), "should have 6 red pawns in target area")
+	}
+
+	{
+		board := NewDefaultBoard()
+		board.Board = [][]Cell{
+			{2, 0, 0, 0, 2},
+			{0, 0, 0, 2, 0},
+			{0, 0, 2, 1, 1},
+			{0, 2, 1, 0, 1},
+			{2, 0, 1, 0, 1},
+		}
+		assert.Equal(t, int8(4), board.CountGreenPawnsInTargetArea(), "should have 4 green pawns in target area")
+		assert.Equal(t, int8(1), board.CountRedPawnsInTargetArea(), "should have 1 red pawn in target area")
+	}
+}

--- a/internal/game/player.go
+++ b/internal/game/player.go
@@ -21,3 +21,21 @@ func (player Player) Color() string {
 	}
 	return "red"
 }
+
+// Green player target area mask.
+var GreenTargetAreaMask = [][]Cell{
+	{0, 0, 0, 0, 0},
+	{0, 0, 0, 0, 0},
+	{0, 0, 0, 0, 1},
+	{0, 0, 0, 1, 1},
+	{0, 0, 1, 1, 1},
+}
+
+// Green player target area mask.
+var RedTargetAreaMask = [][]Cell{
+	{1, 1, 1, 0, 0},
+	{1, 1, 0, 0, 0},
+	{1, 0, 0, 0, 0},
+	{0, 0, 0, 0, 0},
+	{0, 0, 0, 0, 0},
+}


### PR DESCRIPTION
- Add players target area
- Count player pawns in the target area of each player
- Render board cells with a colored background when they contain a pawn in the target area of the player
- Print a scoreboard

https://trello.com/c/FmzGjch3/10-05-as-alice-i-want-to-know-if-a-pawn-is-in-the-target-area

## Screenshots

![default board with scores at 0](https://github.com/user-attachments/assets/0fbcc93c-c05b-4db7-8e87-23b0486e576f)

![pawns in the target area of each player in an ongoing game](https://github.com/user-attachments/assets/93647f95-2b69-41c9-8d80-6fc1dbf24aff)
