### PR TITLE
Show the last move

### DIFF
--- a/cmd/chinese-checkers/cmd.go
+++ b/cmd/chinese-checkers/cmd.go
@@ -69,6 +69,7 @@ func RunCli() error {
 				// Print the board with the moved pawn and the current score.
 				board.Print(os.Stdout)
 				board.PrintScore(os.Stdout)
+				board.PrintLastMove(os.Stdout)
 
 				return nil
 			} else {
@@ -108,6 +109,9 @@ func runGameLoop(board *game.BoardState) {
 
 		// Show the current score.
 		board.PrintScore(os.Stdout)
+
+		// Print the last move.
+		board.PrintLastMove(os.Stdout)
 
 		// Print the previous error if there is one.
 		if len(errMsg) > 0 {

--- a/internal/game/cell.go
+++ b/internal/game/cell.go
@@ -15,8 +15,8 @@ const (
 )
 
 type CellIdentifier struct {
-	Row    int8
-	Column int8
+	Row    int8 `json:"row"`
+	Column int8 `json:"column"`
 }
 
 // Convert a cell identifier to its string format.

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -64,8 +64,9 @@ var gameDefinitions = [...]GameDefinition{
 
 // The main board state.
 type BoardState struct {
-	Board          [][]Cell `json:"board"`
-	CurrentPlayer  Player   `json:"currentPlayer"`
+	Board          [][]Cell         `json:"board"`
+	CurrentPlayer  Player           `json:"currentPlayer"`
+	LastMove       []CellIdentifier `json:"lastMove,omitempty"`
 	stateFile      *string
 	gameDefinition *GameDefinition
 }
@@ -357,6 +358,9 @@ func (board *BoardState) MovePawn(serializedMoveList string) error {
 	board.Board[moveList[len(moveList)-1].Row][moveList[len(moveList)-1].Column] = startPawn
 	// Remove the start pawn from its previous position.
 	board.Board[moveList[0].Row][moveList[0].Column] = 0
+
+	// Store the current move list as the last move.
+	board.LastMove = moveList
 
 	// After moving a pawn, switch player turn.
 	if board.CurrentPlayer == Green {

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -424,3 +424,12 @@ func (board BoardState) GetWinner() Player {
 
 	return None
 }
+
+// Find out who is the previous player.
+func (board BoardState) GetPreviousPlayer() Player {
+	previousPlayer := Green
+	if board.CurrentPlayer == Green {
+		previousPlayer = Red
+	}
+	return previousPlayer
+}

--- a/internal/game/game_cli.go
+++ b/internal/game/game_cli.go
@@ -11,11 +11,8 @@ import (
 func (board *BoardState) PrintLastMove(writer io.Writer) {
 	// Only print the last move if there actually is a last move.
 	if len(board.LastMove) > 0 {
-		// Find out who was the previous player.
-		previousPlayer := Green
-		if board.CurrentPlayer == Green {
-			previousPlayer = Red
-		}
+		// Find out who is the previous player.
+		previousPlayer := board.GetPreviousPlayer()
 
 		// Print the previous player move.
 		fmt.Fprintf(writer, "Last move from %s player: ", previousPlayer.ColoredName())
@@ -35,11 +32,8 @@ func (board *BoardState) PrintLastMove(writer io.Writer) {
 
 // Print the game board to the console.
 func (board *BoardState) Print(writer io.Writer) {
-	// Find out who was the previous player.
-	previousPlayer := Green
-	if board.CurrentPlayer == Green {
-		previousPlayer = Red
-	}
+	// Find out who is the previous player.
+	previousPlayer := board.GetPreviousPlayer()
 
 	// Columns indices.
 	fmt.Fprint(writer, "    ")

--- a/internal/game/game_cli.go
+++ b/internal/game/game_cli.go
@@ -7,8 +7,40 @@ import (
 	"github.com/go-color-term/go-color-term/coloring"
 )
 
+// Print the last move.
+func (board *BoardState) PrintLastMove(writer io.Writer) {
+	// Only print the last move if there actually is a last move.
+	if len(board.LastMove) > 0 {
+		// Find out who was the previous player.
+		previousPlayer := Green
+		if board.CurrentPlayer == Green {
+			previousPlayer = Red
+		}
+
+		// Print the previous player move.
+		fmt.Fprintf(writer, "Last move from %s player: ", previousPlayer.ColoredName())
+
+		lastIndex := len(board.LastMove) - 1
+		for cellIndex, cell := range board.LastMove {
+			// Print each cell string, with a comma to separate move parts.
+			fmt.Fprint(writer, cell.String())
+			if cellIndex != lastIndex {
+				fmt.Fprint(writer, ", ")
+			}
+		}
+
+		fmt.Fprintln(writer)
+	}
+}
+
 // Print the game board to the console.
 func (board *BoardState) Print(writer io.Writer) {
+	// Find out who was the previous player.
+	previousPlayer := Green
+	if board.CurrentPlayer == Green {
+		previousPlayer = Red
+	}
+
 	// Columns indices.
 	fmt.Fprint(writer, "    ")
 	for columnIndex := range board.Board[0] {
@@ -46,7 +78,24 @@ func (board *BoardState) Print(writer io.Writer) {
 				}
 				fmt.Fprint(writer, pawnCellStr)
 			} else {
-				fmt.Fprint(writer, "    ")
+				emptyCellStr := "    "
+
+				// Show a dimmed cell if it was the previous position of a cell.
+				for _, cellPos := range board.LastMove {
+					// Try to find a previous cell matching the current one.
+					if cellPos.Row == int8(rowIndex) && cellPos.Column == int8(columnIndex) {
+						// Build a small circle with a dimmed color of the previous player.
+						emptyCellBuilder := coloring.For("  ⬤ ")
+						if previousPlayer == Green {
+							emptyCellBuilder = emptyCellBuilder.Rgb(0, 70, 0)
+						} else {
+							emptyCellBuilder = emptyCellBuilder.Rgb(84, 0, 0)
+						}
+						emptyCellStr = emptyCellBuilder.String()
+						break
+					}
+				}
+				fmt.Fprint(writer, emptyCellStr)
 			}
 
 			fmt.Fprint(writer, "|")

--- a/internal/game/game_cli_test.go
+++ b/internal/game/game_cli_test.go
@@ -161,3 +161,76 @@ func TestBoardScorePrinting(t *testing.T) {
 		assert.Equal(t, expected, output.String(), "should have printed an accurate scoreboard")
 	}
 }
+
+func TestBoardPrintLastMove(t *testing.T) {
+	board := NewDefaultBoard7()
+	board.CurrentPlayer = Green
+
+	err := board.MovePawn("b2,b4")
+	assert.Nil(t, err, "should move the pawn without error")
+
+	var output bytes.Buffer
+	board.PrintLastMove(&output)
+	assert.Equal(t, "Last move from "+coloring.For("Green").Bold().Green().String()+" player: b2, b4\n", output.String(), "should have an accurate last move")
+}
+
+func TestBoardPrintingWithLastMove(t *testing.T) {
+	board := NewDefaultBoard7()
+	board.CurrentPlayer = Green
+
+	err := board.MovePawn("b2,b4")
+	assert.Nil(t, err, "should move the pawn without error")
+
+	expected := `     1    2    3    4    5    6    7   
+ . +----+----+----+----+----+----+----+
+ a | 🟢 | 🟢 | 🟢 | 🟢 |    |    |    |
+ . +----+----+----+----+----+----+----+
+ b | 🟢 |` + coloring.For("  ⬤ ").Rgb(0, 70, 0).String() + `| 🟢 | 🟢 |    |    |    |
+ . +----+----+----+----+----+----+----+
+ c | 🟢 | 🟢 |    |    |    |    |    |
+ . +----+----+----+----+----+----+----+
+ d | 🟢 |    |    |    |    |    | 🔴 |
+ . +----+----+----+----+----+----+----+
+ e |    |    |    |    |    | 🔴 | 🔴 |
+ . +----+----+----+----+----+----+----+
+ f |    |    |    |    | 🔴 | 🔴 | 🔴 |
+ . +----+----+----+----+----+----+----+
+ g |    |    |    | 🔴 | 🔴 | 🔴 | 🔴 |
+ . +----+----+----+----+----+----+----+
+`
+
+	var output bytes.Buffer
+	board.Print(&output)
+	assert.Equal(t, expected, output.String(), "should have printed an default game board with one last move")
+}
+
+func TestBoardPrintingWithJumpAsLastMove(t *testing.T) {
+	board, err := NewBoardFromStateFile(ongoing7x7GameStateTestPath)
+	assert.Nil(t, err, "should load the board without error")
+	board.CurrentPlayer = Green
+
+	err = board.MovePawn("b2,d2,d4")
+	assert.Nil(t, err, "should move the pawn without error")
+
+	expected := `     1    2    3    4    5    6    7   
+ . +----+----+----+----+----+----+----+
+ a |    | 🟢 | 🟢 |    |    |    |    |
+ . +----+----+----+----+----+----+----+
+ b | 🟢 |` + coloring.For("  ⬤ ").Rgb(0, 70, 0).String() + `| 🟢 | 🟢 |    |    |    |
+ . +----+----+----+----+----+----+----+
+ c | 🟢 | 🟢 |    |    |    |    |    |
+ . +----+----+----+----+----+----+----+
+ d | 🟢 |` + coloring.For("  ⬤ ").Rgb(0, 70, 0).String() + `| 🟢 | 🟢 |    |    | 🔴 |
+ . +----+----+----+----+----+----+----+
+ e |    |    |    |    |    | 🔴 | 🔴 |
+ . +----+----+----+----+----+----+----+
+ f |    |    | 🔴 | 🔴 | 🔴 | 🔴 |    |
+ . +----+----+----+----+----+----+----+
+ g |    |    |    | 🔴 |    | 🔴 | 🔴 |
+ . +----+----+----+----+----+----+----+
+`
+
+	var output bytes.Buffer
+	board.Print(&output)
+	assert.Equal(t, expected, output.String(), "should have printed an default game board with one last move")
+}

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -94,6 +94,16 @@ func TestBoardCloning(t *testing.T) {
 	assert.NotSame(t, &DefaultBoard5.gameDefinition.RedTargetAreaMask[0], &clonedBoard.gameDefinition.RedTargetAreaMask[0], "shouldn't be the same pointer")
 }
 
+func TestPreviousPlayer(t *testing.T) {
+	board := NewDefaultBoard7()
+
+	board.CurrentPlayer = Red
+	assert.Equal(t, Green, board.GetPreviousPlayer(), "the previous player must be Green when the current player is Red")
+
+	board.CurrentPlayer = Green
+	assert.Equal(t, Red, board.GetPreviousPlayer(), "the previous player must be Red when the current player is Green")
+}
+
 func TestMovePawnInDefaultBoard(t *testing.T) {
 	expected := &BoardState{
 		Board: [][]Cell{

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -105,6 +105,7 @@ func TestMovePawnInDefaultBoard(t *testing.T) {
 		},
 		CurrentPlayer:  Red,
 		gameDefinition: &gameDefinitions[0],
+		LastMove:       []CellIdentifier{{2, 0}, {2, 1}},
 	}
 
 	board := NewDefaultBoard5()
@@ -127,6 +128,7 @@ func TestMovePawnInOngoingGameBoard(t *testing.T) {
 		CurrentPlayer:  Green,
 		stateFile:      &stateFilePath,
 		gameDefinition: &gameDefinitions[0],
+		LastMove:       []CellIdentifier{{4, 3}, {4, 2}},
 	}
 
 	board, err := NewBoardFromStateFile(ongoingGameStateTestPath)
@@ -223,7 +225,7 @@ func TestMovePawnAndSave(t *testing.T) {
 	{ // The file should now have been updated with the expected board state.
 		board, err := NewBoardFromStateFile(testFilePath)
 		assert.Nil(t, err)
-		assert.Equal(t, expectedBoard, board, "saved board must be the default board with one moved pawn")
+		assert.Equal(t, expectedBoard, board, "saved board must be the default board with one moved pawn, and a saved last move")
 	}
 
 	os.Remove(testFilePath)


### PR DESCRIPTION
Keep the last move and show it. I've added a simple print and changed the printed board to add a "trail" where the pawn went.

https://trello.com/b/fo6XIyw8/chinese-checkers

## How to test

```shell
make run
```

## Screenshot

![an ongoing game with the last move shown](https://github.com/user-attachments/assets/800b3140-3fc1-4010-96b0-75e5ee12567a)
