### PR TITLE
Remove animated arrow when showing the last move

### DIFF
--- a/web/app/src/ui/move/MoveOverlay.css
+++ b/web/app/src/ui/move/MoveOverlay.css
@@ -34,11 +34,13 @@
 	&.green
 	{
 		background: linear-gradient(90deg, transparent, var(--board-green-background), transparent);
+		> .icon { display: none; }
 	}
 
 	&.red
 	{
 		background: linear-gradient(90deg, transparent, var(--board-red-background), transparent);
+		> .icon { display: none; }
 	}
 }
 


### PR DESCRIPTION
https://trello.com/c/fjIZr2yq#comment-68403e3e1937a9db4c7aa17a

## How to test

```
make start-web-app-dev
make start-mobile-app-dev
```

## Screenshot

![red last move with jumps](https://github.com/user-attachments/assets/89513acd-d3ed-4977-bda4-00d43d72f03a)
