### PR TITLE
Fix moving board when loading players win chances

### DIFF
--- a/web/app/src/ui/board/PlayersWinChances.css
+++ b/web/app/src/ui/board/PlayersWinChances.css
@@ -1,4 +1,9 @@
 
+.win-chances.loader
+{
+	margin: 2.5em auto 3.1em;
+}
+
 .win-chances
 {
 	align-self: stretch;

--- a/web/app/src/ui/board/PlayersWinChances.tsx
+++ b/web/app/src/ui/board/PlayersWinChances.tsx
@@ -10,7 +10,7 @@ export function PlayersWinChances(props: { game: Game }) {
 	return (
 		// Hide the win chances display when an error happen.
 		<ErrorBoundary onError={(error) => showErrorToast(error)} fallback={<></>}>
-			<Suspense fallback={<Loader />}>
+			<Suspense fallback={<Loader className="win-chances" />}>
 				<AsyncPlayersWinChances {...props} />
 			</Suspense>
 		</ErrorBoundary>

--- a/web/app/src/ui/kit/Loader.tsx
+++ b/web/app/src/ui/kit/Loader.tsx
@@ -1,8 +1,9 @@
 import React from "react";
+import { clsx } from "clsx";
 import "./Loader.css";
 
-export function Loader() {
-	return <div className="loader"></div>;
+export function Loader({ className }: { className?: string }) {
+	return <div className={clsx("loader", className)}></div>;
 }
 
 export function LoaderView() {


### PR DESCRIPTION
https://trello.com/c/W774Gf44/115-as-alice-im-having-trouble-predicting-my-next-move-because-the-board-moves-between-turns

## How to test

```shell
make start-web-app-dev
make start-mobile-app-dev
```